### PR TITLE
Default to Machine-remove wget-fix uninstall PATH

### DIFF
--- a/server-jre8/server-jre8.nuspec
+++ b/server-jre8/server-jre8.nuspec
@@ -13,8 +13,6 @@
     <packageSourceUrl>https://github.com/rgra/choco-packages/tree/master/server-jre8</packageSourceUrl>
     <bugTrackerUrl>http://bugs.java.com</bugTrackerUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <dependencies>
-   </dependencies>
     <summary>The Server JRE includes tools for JVM monitoring and tools commonly required for server applications, but does not include browser integration (the Java plug-in).</summary>
     <description>Server JRE (Server Java Runtime Environment) for deploying Java applications on servers. Includes tools for JVM monitoring and tools commonly required for server applications, but does not include browser integration (the Java plug-in), auto-update, nor an installer. 
 

--- a/server-jre8/server-jre8.nuspec
+++ b/server-jre8/server-jre8.nuspec
@@ -14,7 +14,6 @@
     <bugTrackerUrl>http://bugs.java.com</bugTrackerUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <dependency id="wget" version=" 1.17.0.0" />
    </dependencies>
     <summary>The Server JRE includes tools for JVM monitoring and tools commonly required for server applications, but does not include browser integration (the Java plug-in).</summary>
     <description>Server JRE (Server Java Runtime Environment) for deploying Java applications on servers. Includes tools for JVM monitoring and tools commonly required for server applications, but does not include browser integration (the Java plug-in), auto-update, nor an installer. 

--- a/server-jre8/tools/chocolateyInstall.ps1
+++ b/server-jre8/tools/chocolateyInstall.ps1
@@ -27,9 +27,11 @@ $arguments = @{}
 $packageParameters = $env:chocolateyPackageParameters
 
 # Default value
-$InstallationPath = Join-Path (Get-BinRoot) "Java/server-jre"
+# uses deprecated Get-BinRoot
+#$InstallationPath = Join-Path (Get-BinRoot) "Java/server-jre"
+$InstallationPath = Join-Path (Get-ToolsLocation) "Java/server-jre"
 $ForceEnvVars = $false
-$EnvVariableType = "User"
+$EnvVariableType = "Machine"
 
 # Now parse the packageParameters using good old regular expression
 if ($packageParameters) {
@@ -58,9 +60,9 @@ if ($packageParameters) {
         Write-Host "Force Argument Found"
         $ForceEnvVars = $true
     }
-    if ($arguments.ContainsKey("Machine")) {
-        Write-Host "Machine Argument Found"
-        $EnvVariableType = "Machine"
+    if ($arguments.ContainsKey("User")) {
+        Write-Host "User Argument Found"
+        $EnvVariableType = "User"
     }
 
 } else {
@@ -68,6 +70,9 @@ if ($packageParameters) {
 }
 
 Write-Debug "Installing to $InstallationPath, Params: ForceEnvVars=$ForceEnvVars, EnvVariableType=$EnvVariableType"
+
+# Future state, write install options file to use in uninstall (ie /Machine or /User /InstallationPath)
+# This would be easier if installed with Install-ChocolateyZipFile and writing the parameters to $toolsDir aka Invocation.
 
 #Create Temp Folder
 $chocTempDir = Join-Path $env:TEMP "chocolatey"
@@ -90,15 +95,41 @@ if ([System.IO.File]::Exists($tarGzFile)) {
     }
 }
 
-if (![System.IO.File]::Exists($tarGzFile)) {
-  $wget = Join-Path "$env:ChocolateyInstall" '\bin\wget.exe'
-  Write-Debug "wget found at `'$wget`'"
+# Added some .NET code to remove the dependency on wget
+# If chocolatey >= 0.9.10 could use Get-ChocolateyWebFile with $options
+# Currently investigating a bug where it doesn't seem to pass the cookie in properly
+#if ($env:ChocolateyVersion -gt "0.9.10") {
+#$options =
+#@{
+#  Headers = @{
+#    Cookie = " oraclelicense=accept-securebackup-cookie";
+#  }
+#}
+#
+#Write-Debug "Downloading file $tarGzFile using Get-ChocolateyWebFile"
+#Get-ChocolateyWebFile -PackageName $packageName -FileFullPath $tarGzFile -Url $url -Checksum $checksum -ChecksumType SHA256 -Options $options
+# } # End Get-ChocolateyWebFile
+#
+# } else {
+# Native .NET download for choco < 0.9.10
+Write-Debug "Downloading file $tarGzFile using System.Net.WebClient"
+$wc = New-Object System.Net.WebClient
+$wc.Headers.Add([System.Net.HttpRequestHeader]::Cookie, "oraclelicense=accept-securebackup-cookie"); 
+$wc.DownloadFile($url, $tarGzFile)
+Get-ChecksumValid -File $tarGzFile -Checksum $checksum -ChecksumType SHA256
+# } # End native .NET block
 
-  #Download file. Must set Cookies to accept license
-  Write-Debug "Downloading file $tarGzFile"
-  .$wget --quiet --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" $url -O $tarGzFile
-  Get-ChecksumValid -File $tarGzFile -Checksum $checksum -ChecksumType SHA256
-}
+# Wget dependency block {
+#if (![System.IO.File]::Exists($tarGzFile)) {
+#  $wget = Join-Path "$env:ChocolateyInstall" '\bin\wget.exe'
+#  Write-Debug "wget found at `'$wget`'"
+#
+#  #Download file. Must set Cookies to accept license
+#  Write-Debug "Downloading file $tarGzFile"
+#  .$wget --quiet --no-check-certificate --header "Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie" $url -O $tarGzFile
+#  Get-ChecksumValid -File $tarGzFile -Checksum $checksum -ChecksumType SHA256
+#}
+# } # End wget dependency block
 
 #Extract gz to .tar File
 Get-ChocolateyUnzip $tarGzFile $tempDir
@@ -117,5 +148,5 @@ else {
 }
 
 Install-ChocolateyPath '%JAVA_HOME%\bin' $EnvVariableType
-
+Get-EnvironmentVariable -Name 'PATH' -Scope $EnvVariableType -PreserveVariables
 #Remove-Item -Recurse $tempDir

--- a/server-jre8/tools/chocolateyUninstall.ps1
+++ b/server-jre8/tools/chocolateyUninstall.ps1
@@ -2,18 +2,49 @@
 
 $versionArray = $env:chocolateyPackageVersion.Split(".")
 $folderVersion = "jdk1.$($versionArray[0]).$($versionArray[1])_$($versionArray[2])"
-$InstallationPath = Join-Path $env:ProgramFiles "Java/server-jre"
-$EnvVariableType = "User"
+# This will need updated to handle install options file eventually
+$InstallationPath = Join-Path (Get-ToolsLocation) "Java/server-jre"
+$EnvVariableType = "Machine"
 
 if ([System.IO.Directory]::Exists($InstallationPath)) {
     Write-Debug "Uninstalling $packageName from $InstallationPath"
 
     $JavaHome = Get-EnvironmentVariable "JAVA_HOME" $EnvVariableType
     if($JavaHome -eq $InstallationPath) {
-        Install-ChocolateyEnvironmentVariable -variableName "JAVA_HOME" -variableValue "" -variableType $EnvVariableType
+        Install-ChocolateyEnvironmentVariable -variableName "JAVA_HOME" -variableValue $null -variableType $EnvVariableType
     }
     Remove-Item -Recurse $InstallationPath
 }
 else {
     Write-Debug "No $packageName found at $InstallationPath"
 }
+
+# Remove installed variable(s) from PATH
+# Loop via @DarwinJS on GitHub as a temp workaround, https://github.com/chocolatey/choco/issues/310
+#To avoid bad situations - does not use substring matching, regular expressions are "exact" matches
+#Removes duplicates of the target removal path, Cleans up double ";", Handles ending "\"
+
+# Expanded path looks like 'C:\tools\Java\server-jre\jdk1.8.0_101\bin'
+# Need to escape the backslash in the regex
+[regex] $PathsToRemove = "^(%JAVA_HOME%\\bin)"
+$environmentPath = Get-EnvironmentVariable -Name 'PATH' -Scope $EnvVariableType -PreserveVariables
+$environmentPath
+[string[]]$newpath = ''
+foreach ($path in $environmentPath.split(';'))
+{
+  If (($path) -and ($path -notmatch $PathsToRemove))
+    {
+        [string[]]$newpath += "$path"
+        "$path added to `$newpath"
+    } else {
+        "Path to remove found: $path"
+    }
+}
+$AssembledNewPath = ($newpath -join(';')).trimend(';')
+$AssembledNewPath
+
+Install-ChocolateyEnvironmentVariable -variableName 'PATH' -variableValue $AssembledNewPath -variableType $EnvVariableType
+"Path with variables"
+$newEnvironmentPath = Get-EnvironmentVariable -Name 'PATH' -Scope $EnvVariableType -PreserveVariables
+"Path with values instead of variables"
+$env:PATH


### PR DESCRIPTION
I didn't bump the version of Java, as I wanted to test with a known working state. Updating it to the latest may be worthwhile before publishing.

This inverts the previous behavior of installing as /User by default to install as /Machine. The /User option has limited usefulness when running Java programs as a service account as it would then need installed from the service account which may not have the appropriate permissions to do so. Installing as /Machine places it in the system-wide PATH allowing any account to use Java.

Summary:
Default of /Machine allows services to find and use Java
Wget isn't required for the magic cookie, native .NET is good
Uninstall was looking in Program Files and not the Chocolatey install
location, now removes %JAVA_HOME%\bin from the PATH

TODO: May add in install option capture to file for uninstall/upgrade
The previous (and current) uninstallers don't handle the case where a user customized the installation directory, this may be addressed in a future release by Chocolatey saving the parameters passed in, or the poor man's way of saving our own install-options.txt file and parsing that via the uninstall script.