### PR TITLE
Use DefaultNetworkCredentials when downloading a file using WebClient

### DIFF
--- a/server-jre8/tools/chocolateyInstall.ps1
+++ b/server-jre8/tools/chocolateyInstall.ps1
@@ -121,6 +121,7 @@ if ([System.IO.File]::Exists($tarGzFile)) {
 Write-Debug "Downloading file $tarGzFile using System.Net.WebClient"
 $wc = New-Object System.Net.WebClient
 $wc.Headers.Add([System.Net.HttpRequestHeader]::Cookie, "oraclelicense=accept-securebackup-cookie"); 
+$wc.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
 $wc.DownloadFile($url, $tarGzFile)
 Get-ChecksumValid -File $tarGzFile -Checksum $checksum -ChecksumType SHA256
 # } # End native .NET block


### PR DESCRIPTION
This enables installations behind a proxy by using the default system credentials.

Regarding https://github.com/rgra/choco-packages/issues/20: 
It doesn't use the proxy defined with the `--proxy` flag when running chocolatey but it at least uses the global credentials. 