### PR TITLE
Update to 8u144

### DIFF
--- a/server-jre/server-jre.nuspec
+++ b/server-jre/server-jre.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>server-jre</id>
-    <version>8.0.131</version>
+    <version>8.0.144</version>
     <title>Server JRE (Java SE Runtime Environment)</title>
      <authors>Oracle</authors>
     <owners>rgra</owners>
@@ -14,7 +14,7 @@
     <packageSourceUrl>https://github.com/rgra/choco-packages/tree/master/server-jre</packageSourceUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <dependency id="server-jre8" version="8.0.131" />
+      <dependency id="server-jre8" version="8.0.144" />
    </dependencies>
    <summary>The Server JRE includes tools for JVM monitoring and tools commonly required for server applications, but does not include browser integration (the Java plug-in).</summary>
     <description>Server JRE (Server Java Runtime Environment) for deploying Java applications on servers. Includes tools for JVM monitoring and tools commonly required for server applications, but does not include browser integration (the Java plug-in), auto-update, nor an installer. 

--- a/server-jre8/server-jre8.nuspec
+++ b/server-jre8/server-jre8.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>server-jre8</id>
-    <version>8.0.131</version>
+    <version>8.0.144</version>
     <title>Server JRE (Java SE Runtime Environment)</title>
      <authors>Oracle</authors>
     <owners>rgra</owners>

--- a/server-jre8/tools/chocolateyInstall.ps1
+++ b/server-jre8/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageName = $env:chocolateyPackageName
 # The buildNumber should be easier to determine or pass from the nuspec
 $buildNumber = "11"
-$checksum = "1806ebe235eab2b21c893acbf0b287a392ce6b5edfea3286fc8ff7d6defb19cb"
+$checksum = "20d5e1b2b4c789b6d0c378ffa9b2ff12448f31f0224ba482a338790cff18020a"
 
 
 # Discard any -pre/-beta/-testing appended to avoid releasing an unfinished on Chocolatey.org
@@ -19,7 +19,7 @@ $fileName = "$fileNameBase.tar.gz"
 
 # Oracle got clever and is throwing a hash/sessionID into the path
 #$url        = "http://download.oracle.com/otn-pub/java/jdk/$($majorVersion)u$($updateVersion)-b$buildNumber/$fileName"
-$url = "http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/server-jre-8u131-windows-x64.tar.gz"
+$url = "http://download.oracle.com/otn-pub/java/jdk/8u144-b01/090f390dda5b47b9b721c7dfaa008135/server-jre-8u144-windows-x64.tar.gz"
 
 $osBitness = Get-ProcessorBits
 # 32-bit not supported


### PR DESCRIPTION
I didn't update the $buildNumber as it's no longer in use but this should be the correct SHA256 checksum and download url for the latest JRE8 release, u144.